### PR TITLE
Add ISO support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 
-# QtCreator 4.8< compilation database 
+# QtCreator 4.8< compilation database
 compile_commands.json
 
 # QtCreator local machine specific files for imported projects

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ compile_commands.json
 # QtCreator local machine specific files for imported projects
 *creator.user*
 
-*.exe
-gz-gui
+# Workspace files
 .vscode/
-test/
+debug/
+release/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ compile_commands.json
 
 # QtCreator local machine specific files for imported projects
 *creator.user*
+
+*.exe
+gz-gui
+.vscode/
+test/

--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,7 @@ bool check_files()
 #endif
         {"lua/patch-rom.lua", S_IFREG},
         {"lua/patch-wad.lua", S_IFREG},
+        {"lua/patch-iso.lua", S_IFREG},
         {"lua/rom_table.lua", S_IFREG},
         {"lua/inject_ucode.lua", S_IFREG},
         {"ups", S_IFDIR},

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -376,7 +376,7 @@ void MainWindow::init_iso_tab()
     connect(ui->checkbox_iso_no_trim, &QCheckBox::stateChanged,
         [this](int state)
         {
-            settings.iso_no_trim = state;
+            settings.iso_do_trim = state;
             update_go_state();
         });
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -24,9 +24,9 @@ MainWindow::MainWindow(QWidget *parent)
             update_go_state();
         });
 
-    connect_rom();
-    connect_wad();
-    connect_iso();
+    init_rom_tab();
+    init_wad_tab();
+    init_iso_tab();
 
     connect(ui->button_go, &QPushButton::clicked,
         [this]()
@@ -87,9 +87,8 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
-void MainWindow::connect_rom()
+void MainWindow::init_rom_tab()
 {
-
     connect(ui->button_rom, &QPushButton::clicked,
         [this]()
         {
@@ -130,7 +129,7 @@ void MainWindow::connect_rom()
         });
 }
 
-void MainWindow::connect_wad()
+void MainWindow::init_wad_tab()
 {
     connect(ui->button_wad, &QPushButton::clicked,
         [this]()
@@ -242,49 +241,7 @@ void MainWindow::connect_wad()
         });
 }
 
-void MainWindow::update_iso_mq_state(QString *path)
-{
-    //! TODO: improve how the label text update is handled
-    QString new_text = "This game doesn't have Master Quest.";
-
-    settings.iso_is_mq = false;
-
-    if (path != nullptr) {
-        QFile iso(*path);
-
-        // technically this isn't a text file but
-        // we only need to read the first 6 characters of the file
-        if (iso.open(QFile::ReadOnly | QFile::Text)) {
-            QTextStream stream(&iso);
-            QString game_id = stream.read(6);
-
-            // supported MQ disc IDs (JP and US)
-            if (game_id == "D43J01" || game_id == "D43E01") {
-                new_text = QString::fromStdString(settings.iso_extrom_mq_path);
-
-                settings.iso_is_mq = true;
-
-                if (new_text != "") {
-                    new_text.remove(0, new_text.lastIndexOf('\\') + 1);
-                    new_text.remove(0, new_text.lastIndexOf('/') + 1);
-                } else {
-                    new_text = default_extrom_mq_iso_text;
-                }
-            }
-        } else {
-            QMessageBox::warning(nullptr, "", "ERROR: The ISO can't be opened.");
-        }
-    }
-
-    // update the ui accordingly
-    ui->checkbox_extrom_mq_iso->setEnabled(settings.iso_is_mq);
-    ui->checkbox_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->button_extrom_mq_iso->setDisabled(ui->checkbox_extrom_mq_iso->isChecked());
-    ui->button_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->label_extrom_mq_iso->setText(new_text);
-}
-
-void MainWindow::connect_iso()
+void MainWindow::init_iso_tab()
 {
     default_extrom_mq_iso_text = ui->label_extrom_mq_iso->text();
     update_iso_mq_state(nullptr);
@@ -422,6 +379,48 @@ void MainWindow::connect_iso()
             settings.iso_no_trim = state;
             update_go_state();
         });
+}
+
+void MainWindow::update_iso_mq_state(QString *path)
+{
+    //! TODO: improve how the label text update is handled
+    QString new_text = "This game doesn't have Master Quest.";
+
+    settings.iso_is_mq = false;
+
+    if (path != nullptr) {
+        QFile iso(*path);
+
+        // technically this isn't a text file but
+        // we only need to read the first 6 characters of the file
+        if (iso.open(QFile::ReadOnly | QFile::Text)) {
+            QTextStream stream(&iso);
+            QString game_id = stream.read(6);
+
+            // supported MQ disc IDs (JP and US)
+            if (game_id == "D43J01" || game_id == "D43E01") {
+                new_text = QString::fromStdString(settings.iso_extrom_mq_path);
+
+                settings.iso_is_mq = true;
+
+                if (new_text != "") {
+                    new_text.remove(0, new_text.lastIndexOf('\\') + 1);
+                    new_text.remove(0, new_text.lastIndexOf('/') + 1);
+                } else {
+                    new_text = default_extrom_mq_iso_text;
+                }
+            }
+        } else {
+            QMessageBox::warning(nullptr, "", "ERROR: The ISO can't be opened.");
+        }
+    }
+
+    // update the ui accordingly
+    ui->checkbox_extrom_mq_iso->setEnabled(settings.iso_is_mq);
+    ui->checkbox_extrom_mq_iso->setVisible(settings.iso_is_mq);
+    ui->button_extrom_mq_iso->setDisabled(ui->checkbox_extrom_mq_iso->isChecked());
+    ui->button_extrom_mq_iso->setVisible(settings.iso_is_mq);
+    ui->label_extrom_mq_iso->setText(new_text);
 }
 
 void MainWindow::update_go_state()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -244,7 +244,8 @@ void MainWindow::connect_wad()
 
 void MainWindow::update_iso_mq_state(QString *path)
 {
-    QString last_text;
+    //! TODO: improve how the label text update is handled
+    QString new_text = "This game doesn't have Master Quest.";
 
     settings.iso_is_mq = false;
 
@@ -259,31 +260,33 @@ void MainWindow::update_iso_mq_state(QString *path)
 
             // supported MQ disc IDs (JP and US)
             if (game_id == "D43J01" || game_id == "D43E01") {
+                new_text = QString::fromStdString(settings.iso_extrom_mq_path);
+
                 settings.iso_is_mq = true;
+
+                if (new_text != "") {
+                    new_text.remove(0, new_text.lastIndexOf('\\') + 1);
+                    new_text.remove(0, new_text.lastIndexOf('/') + 1);
+                } else {
+                    new_text = default_extrom_mq_iso_text;
+                }
             }
         } else {
-            QMessageBox::warning(nullptr, "", "ERROR: The path to the ISO cannot be found.");
+            QMessageBox::warning(nullptr, "", "ERROR: The ISO can't be opened.");
         }
     }
 
     // update the ui accordingly
     ui->checkbox_extrom_mq_iso->setEnabled(settings.iso_is_mq);
     ui->checkbox_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->button_extrom_mq_iso->setDisabled(ui->checkbox_extrom_mq_iso->isEnabled());
-    ui->button_extrom_mq_iso->setVisible(ui->checkbox_extrom_mq_iso->isVisible());
-    last_text = ui->label_extrom_mq_iso->text();
-
-    if (settings.iso_is_mq) {
-        ui->label_extrom_mq_iso->setText(last_extrom_mq_iso_text);
-    } else {
-        ui->label_extrom_mq_iso->setText("This game doesn't have Master Quest.");
-    }
-
-    last_extrom_mq_iso_text = last_text;
+    ui->button_extrom_mq_iso->setDisabled(ui->checkbox_extrom_mq_iso->isChecked());
+    ui->button_extrom_mq_iso->setVisible(settings.iso_is_mq);
+    ui->label_extrom_mq_iso->setText(new_text);
 }
 
 void MainWindow::connect_iso()
 {
+    default_extrom_mq_iso_text = ui->label_extrom_mq_iso->text();
     update_iso_mq_state(nullptr);
 
     connect(ui->button_iso, &QPushButton::clicked,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -416,9 +416,7 @@ void MainWindow::update_iso_mq_state(QString *path)
     }
 
     // update the ui accordingly
-    ui->checkbox_extrom_mq_iso->setEnabled(settings.iso_is_mq);
     ui->checkbox_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->button_extrom_mq_iso->setDisabled(ui->checkbox_extrom_mq_iso->isChecked());
     ui->button_extrom_mq_iso->setVisible(settings.iso_is_mq);
     ui->label_extrom_mq_iso->setText(new_text);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -13,9 +13,8 @@ MainWindow::MainWindow(QWidget *parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    resize(minimumWidth(), minimumHeight());
 
-    // set patch_mode depending on the current tab index
+    // Set patch_mode depending on the current tab index
     connect(ui->tabwidget, &QTabWidget::currentChanged,
         [this](int index)
         {
@@ -44,8 +43,7 @@ MainWindow::MainWindow(QWidget *parent)
                     *result = QFileDialog::
                         getSaveFileName(&pd, caption, dir, filter,
                                         selectedFilter, options);
-                },
-                    Qt::BlockingQueuedConnection);
+                }, Qt::BlockingQueuedConnection);
             connect(&patcher, &Patcher::finished, this,
                 [&pd, &patcher]()
                 {
@@ -107,7 +105,7 @@ void MainWindow::init_rom_tab()
     connect(ui->checkbox_ucode, &QCheckBox::stateChanged,
         [this](int state)
         {
-            settings.opt_ucode = state;
+            settings.rom_opt_ucode = state;
             update_go_state();
         });
 
@@ -118,11 +116,11 @@ void MainWindow::init_rom_tab()
                 getOpenFileName(this, "Select ROM", "",
                                 "Nintendo 64 ROM (*.z64 *.v64 *.n64)");
             if (!path.isEmpty()) {
-                settings.ucode_path = path.toStdString();
+                settings.rom_ucode_path = path.toStdString();
                 path.remove(0, path.lastIndexOf('\\') + 1);
                 path.remove(0, path.lastIndexOf('/') + 1);
                 ui->label_ucode->setText(path);
-                settings.opt_ucode = true;
+                settings.rom_opt_ucode = true;
                 ui->checkbox_ucode->setCheckState(Qt::Checked);
             }
             update_go_state();
@@ -149,7 +147,7 @@ void MainWindow::init_wad_tab()
     connect(ui->checkbox_extrom, &QCheckBox::stateChanged,
         [this](int state)
         {
-            settings.opt_extrom = state;
+            settings.wad_opt_extrom = state;
             ui->button_extrom->setEnabled(state);
             update_go_state();
         });
@@ -161,11 +159,11 @@ void MainWindow::init_wad_tab()
                 getOpenFileName(this, "Select ROM", "",
                                 "Nintendo 64 ROM (*.z64 *.v64 *.n64)");
             if (!path.isEmpty()) {
-                settings.extrom_path = path.toStdString();
+                settings.wad_extrom_path = path.toStdString();
                 path.remove(0, path.lastIndexOf('\\') + 1);
                 path.remove(0, path.lastIndexOf('/') + 1);
                 ui->label_extrom->setText(path);
-                settings.opt_extrom = true;
+                settings.wad_opt_extrom = true;
                 ui->checkbox_extrom->setCheckState(Qt::Checked);
             }
             update_go_state();
@@ -184,7 +182,7 @@ void MainWindow::init_wad_tab()
             switch (index) {
                 case 0: {
                     ui->combobox_id->removeItem(2);
-                    settings.channel_id.clear();
+                    settings.wad_channel_id.clear();
                     break;
                 }
                 case 1: {
@@ -196,7 +194,7 @@ void MainWindow::init_wad_tab()
                     if (ok && !text.isEmpty()) {
                         ui->combobox_id->addItem(text);
                         ui->combobox_id->setCurrentIndex(2);
-                        settings.channel_id = text.toStdString();
+                        settings.wad_channel_id = text.toStdString();
                     }
                     else
                         ui->combobox_id->setCurrentIndex(0);
@@ -211,7 +209,7 @@ void MainWindow::init_wad_tab()
             switch (index) {
                 case 0: {
                     ui->combobox_title->removeItem(2);
-                    settings.channel_title.clear();
+                    settings.wad_channel_title.clear();
                     break;
                 }
                 case 1: {
@@ -223,7 +221,7 @@ void MainWindow::init_wad_tab()
                     if (ok && !text.isEmpty()) {
                         ui->combobox_title->addItem(text);
                         ui->combobox_title->setCurrentIndex(2);
-                        settings.channel_title = text.toStdString();
+                        settings.wad_channel_title = text.toStdString();
                     }
                     else
                         ui->combobox_title->setCurrentIndex(0);
@@ -244,7 +242,6 @@ void MainWindow::init_wad_tab()
 void MainWindow::init_iso_tab()
 {
     default_extrom_mq_iso_text = ui->label_extrom_mq_iso->text();
-    update_iso_mq_state(nullptr);
 
     connect(ui->button_iso, &QPushButton::clicked,
         [this]()
@@ -253,7 +250,6 @@ void MainWindow::init_iso_tab()
                 getOpenFileName(this, "Select ISO", "",
                                 "Nintendo GameCube ISO (*.iso)");
             if (!path.isEmpty()) {
-                update_iso_mq_state(&path);
                 settings.iso_path = path.toStdString();
                 path.remove(0, path.lastIndexOf('\\') + 1);
                 path.remove(0, path.lastIndexOf('/') + 1);
@@ -261,7 +257,7 @@ void MainWindow::init_iso_tab()
             }
             update_go_state();
         });
-    
+
     connect(ui->checkbox_extrom_iso, &QCheckBox::stateChanged,
         [this](int state)
         {
@@ -269,7 +265,7 @@ void MainWindow::init_iso_tab()
             ui->button_extrom_iso->setEnabled(state);
             update_go_state();
         });
-    
+
     connect(ui->button_extrom_iso, &QPushButton::clicked,
         [this]()
         {
@@ -286,7 +282,7 @@ void MainWindow::init_iso_tab()
             }
             update_go_state();
         });
-    
+
     connect(ui->checkbox_extrom_mq_iso, &QCheckBox::stateChanged,
         [this](int state)
         {
@@ -318,14 +314,14 @@ void MainWindow::init_iso_tab()
             settings.iso_remap = static_cast<PatcherSettings::
                                              controller_remap_t>(index);
         });
-    
+
     connect(ui->combobox_id_iso, QOverload<int>::of(&QComboBox::activated), this,
         [this](int index)
         {
             switch (index) {
                 case 0: {
                     ui->combobox_id_iso->removeItem(2);
-                    settings.game_id.clear();
+                    settings.iso_game_id.clear();
                     break;
                 }
                 case 1: {
@@ -337,7 +333,7 @@ void MainWindow::init_iso_tab()
                     if (ok && !text.isEmpty()) {
                         ui->combobox_id_iso->addItem(text);
                         ui->combobox_id_iso->setCurrentIndex(2);
-                        settings.game_id = text.toStdString();
+                        settings.iso_game_id = text.toStdString();
                     }
                     else
                         ui->combobox_id_iso->setCurrentIndex(0);
@@ -345,14 +341,14 @@ void MainWindow::init_iso_tab()
                 }
             }
         });
-    
+
     connect(ui->combobox_title_iso, QOverload<int>::of(&QComboBox::activated), this,
         [this](int index)
         {
             switch (index) {
                 case 0: {
                     ui->combobox_title_iso->removeItem(2);
-                    settings.game_name.clear();
+                    settings.iso_game_name.clear();
                     break;
                 }
                 case 1: {
@@ -364,7 +360,7 @@ void MainWindow::init_iso_tab()
                     if (ok && !text.isEmpty()) {
                         ui->combobox_title_iso->addItem(text);
                         ui->combobox_title_iso->setCurrentIndex(2);
-                        settings.game_name = text.toStdString();
+                        settings.iso_game_name = text.toStdString();
                     }
                     else
                         ui->combobox_title_iso->setCurrentIndex(0);
@@ -372,7 +368,7 @@ void MainWindow::init_iso_tab()
                 }
             }
         });
-    
+
     connect(ui->checkbox_iso_no_trim, &QCheckBox::stateChanged,
         [this](int state)
         {
@@ -381,71 +377,26 @@ void MainWindow::init_iso_tab()
         });
 }
 
-void MainWindow::update_iso_mq_state(QString *path)
-{
-    //! TODO: improve how the label text update is handled
-    QString new_text = "This game doesn't have Master Quest.";
-
-    settings.iso_is_mq = false;
-
-    if (path != nullptr) {
-        QFile iso(*path);
-
-        // technically this isn't a text file but
-        // we only need to read the first 6 characters of the file
-        if (iso.open(QFile::ReadOnly | QFile::Text)) {
-            QTextStream stream(&iso);
-            QString game_id = stream.read(6);
-
-            // supported MQ disc IDs (JP and US)
-            if (game_id == "D43J01" || game_id == "D43E01") {
-                new_text = QString::fromStdString(settings.iso_extrom_mq_path);
-
-                settings.iso_is_mq = true;
-
-                if (new_text != "") {
-                    new_text.remove(0, new_text.lastIndexOf('\\') + 1);
-                    new_text.remove(0, new_text.lastIndexOf('/') + 1);
-                } else {
-                    new_text = default_extrom_mq_iso_text;
-                }
-            }
-        } else {
-            QMessageBox::warning(nullptr, "", "ERROR: The ISO can't be opened.");
-        }
-    }
-
-    // update the ui accordingly
-    ui->checkbox_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->button_extrom_mq_iso->setVisible(settings.iso_is_mq);
-    ui->label_extrom_mq_iso->setText(new_text);
-}
-
 void MainWindow::update_go_state()
 {
     bool enable_go = false;
     switch (settings.patch_mode) {
         case PatcherSettings::patch_mode_t::ROM: {
             enable_go = !settings.rom_path.empty()
-                        && (!settings.opt_ucode
-                            || !settings.ucode_path.empty());
+                        && (!settings.rom_opt_ucode
+                            || !settings.rom_ucode_path.empty());
             break;
         }
         case PatcherSettings::patch_mode_t::WAD: {
             enable_go = !settings.wad_path.empty()
-                        && (!settings.opt_extrom
-                            || !settings.extrom_path.empty());
+                        && (!settings.wad_opt_extrom
+                            || !settings.wad_extrom_path.empty());
             break;
         }
         case PatcherSettings::patch_mode_t::ISO: {
-            if (settings.iso_is_mq) {
-                enable_go = !settings.iso_path.empty()
-                            && (!settings.iso_opt_extrom || !settings.iso_extrom_path.empty())
-                            && (!settings.iso_opt_extrom_mq || !settings.iso_extrom_mq_path.empty());
-            } else {
-                enable_go = !settings.iso_path.empty()
-                            && (!settings.iso_opt_extrom || !settings.iso_extrom_path.empty());
-            }
+            enable_go = !settings.iso_path.empty()
+                        && (!settings.iso_opt_extrom || !settings.iso_extrom_path.empty())
+                        && (!settings.iso_opt_extrom_mq || !settings.iso_extrom_mq_path.empty());
             break;
         }
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -18,9 +18,9 @@ private:
     Ui::MainWindow *ui;
     QString default_extrom_mq_iso_text;
 
-    void connect_rom();
-    void connect_wad();
-    void connect_iso();
+    void init_rom_tab();
+    void init_wad_tab();
+    void init_iso_tab();
     void update_iso_mq_state(QString *path);
     void update_go_state();
 };

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -16,7 +16,7 @@ public:
 
 private:
     Ui::MainWindow *ui;
-    QString last_extrom_mq_iso_text;
+    QString default_extrom_mq_iso_text;
 
     void connect_rom();
     void connect_wad();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -16,7 +16,12 @@ public:
 
 private:
     Ui::MainWindow *ui;
+    QString last_extrom_mq_iso_text;
 
+    void connect_rom();
+    void connect_wad();
+    void connect_iso();
+    void update_iso_mq_state(QString *path);
     void update_go_state();
 };
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,7 +21,6 @@ private:
     void init_rom_tab();
     void init_wad_tab();
     void init_iso_tab();
-    void update_iso_mq_state(QString *path);
     void update_go_state();
 };
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -15,35 +15,6 @@
   </property>
   <widget class="QWidget" name="widget">
    <layout class="QGridLayout">
-    <item row="1" column="1">
-     <widget class="QPushButton" name="button_go">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string>Go!</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <spacer>
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>0</width>
-        <height>0</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
     <item row="0" column="0" colspan="2">
      <widget class="QTabWidget" name="tabwidget">
       <property name="currentIndex">
@@ -214,6 +185,9 @@
            </item>
            <item>
             <widget class="QPushButton" name="button_extrom">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -237,7 +211,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="label_remap">
              <property name="text">
-              <string>Controller remapping</string>
+              <string>Controller Remapping</string>
              </property>
             </widget>
            </item>
@@ -296,7 +270,7 @@
            <item row="2" column="0">
             <widget class="QLabel" name="label_title">
              <property name="text">
-              <string>Channel title</string>
+              <string>Channel Title</string>
              </property>
             </widget>
            </item>
@@ -336,7 +310,7 @@
               </sizepolicy>
              </property>
              <property name="currentIndex">
-              <number>3</number>
+              <number>0</number>
              </property>
              <item>
               <property name="text">
@@ -355,7 +329,7 @@
              </item>
              <item>
               <property name="text">
-               <string>Region free</string>
+               <string>Region Free</string>
               </property>
              </item>
             </widget>
@@ -378,6 +352,292 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tab_iso">
+       <attribute name="title">
+        <string>Patch an ISO</string>
+       </attribute>
+       <layout class="QVBoxLayout">
+        <item>
+         <widget class="QGroupBox" name="groupbox_iso">
+          <property name="title">
+           <string>ISO</string>
+          </property>
+          <layout class="QVBoxLayout">
+           <item>
+            <widget class="QLabel" name="label_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>No ISO selected</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="button_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Select</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupbox_extrom_iso">
+          <property name="title">
+           <string>ROM</string>
+          </property>
+          <layout class="QVBoxLayout">
+           <item>
+            <widget class="QCheckBox" name="checkbox_extrom_iso">
+             <property name="text">
+              <string>Use external ROM</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_extrom_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>No ROM selected</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="button_extrom_iso">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Select</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupbox_extrom_mq_iso">
+          <property name="title">
+           <string>MQ ROM</string>
+          </property>
+          <layout class="QVBoxLayout">
+           <item>
+            <widget class="QCheckBox" name="checkbox_extrom_mq_iso">
+             <property name="text">
+              <string>Use external ROM</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_extrom_mq_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>No ROM selected</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="button_extrom_mq_iso">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Select</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupbox_options_iso">
+          <property name="title">
+           <string>Options</string>
+          </property>
+          <layout class="QGridLayout">
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_title_iso">
+             <property name="text">
+              <string>Game Name</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_id_iso">
+             <property name="text">
+              <string>Game ID</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="combobox_title_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <item>
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Custom...</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="combobox_id_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <item>
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Custom...</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="combobox_remap_iso">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <item>
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Raphnet</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>None</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_remap_iso">
+             <property name="text">
+              <string>Controller Remapping</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QCheckBox" name="checkbox_iso_no_trim">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Remove Large Files</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer>
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <spacer>
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item row="1" column="1">
+     <widget class="QPushButton" name="button_go">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Go!</string>
+      </property>
      </widget>
     </item>
    </layout>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>343</width>
-    <height>524</height>
+    <width>383</width>
+    <height>721</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -211,7 +211,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="label_remap">
              <property name="text">
-              <string>Controller Remapping</string>
+              <string>Controller remapping</string>
              </property>
             </widget>
            </item>
@@ -270,7 +270,7 @@
            <item row="2" column="0">
             <widget class="QLabel" name="label_title">
              <property name="text">
-              <string>Channel Title</string>
+              <string>Channel title</string>
              </property>
             </widget>
            </item>
@@ -329,7 +329,7 @@
              </item>
              <item>
               <property name="text">
-               <string>Region Free</string>
+               <string>Region free</string>
               </property>
              </item>
             </widget>
@@ -491,7 +491,7 @@
            <item row="3" column="0">
             <widget class="QLabel" name="label_title_iso">
              <property name="text">
-              <string>Game Name</string>
+              <string>Game name</string>
              </property>
             </widget>
            </item>
@@ -570,7 +570,7 @@
            <item row="1" column="0">
             <widget class="QLabel" name="label_remap_iso">
              <property name="text">
-              <string>Controller Remapping</string>
+              <string>Controller remapping</string>
              </property>
             </widget>
            </item>
@@ -587,7 +587,7 @@
            <item row="4" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
-              <string>Remove Large Files</string>
+              <string>Remove large files</string>
              </property>
             </widget>
            </item>

--- a/patcher.cpp
+++ b/patcher.cpp
@@ -613,6 +613,8 @@ int Patcher::patch()
                 cmd += " -m " + quote(settings.iso_extrom_path);
             if (settings.iso_is_mq && settings.iso_opt_extrom_mq)
                 cmd += " --mq-rom " + quote(settings.iso_extrom_mq_path);
+            if (!settings.iso_do_trim)
+                cmd += " --no-trim";
             cmd += " -o " + quote(iso_path) + " " + quote(settings.iso_path);
 
             emit output(QString::fromStdString("executing: " + cmd + "\n"));
@@ -624,24 +626,25 @@ int Patcher::patch()
             std::string gz_iso_name = std::move(output_str);
             while (!gz_iso_name.empty() && isspace(gz_iso_name.back()))
                 gz_iso_name.pop_back();
-            
+
             QString save_name;
             emit needSaveFileName(&save_name, "Save as...", gz_iso_name.c_str(),
                                   "Nintendo GameCube ISO (*.iso)");
             if (save_name.isEmpty()) {
                 status = 0;
                 break;
+            }
 
             emit output("saving: " + save_name + "\n");
             QFile iso_file(iso_path.c_str());
             iso_file.rename(save_name);
             if (iso_file.error() == QFile::RenameError) {
-              QFile::remove(save_name);
-              iso_file.rename(save_name);
+                QFile::remove(save_name);
+                iso_file.rename(save_name);
             }
             if (iso_file.error() != QFile::NoError)
-              throw std::runtime_error(iso_file.errorString().toStdString());
-            }
+                throw std::runtime_error(iso_file.errorString().toStdString());
+
             break;
         }
     }

--- a/patcher.cpp
+++ b/patcher.cpp
@@ -504,9 +504,9 @@ int Patcher::patch()
             while (!gz_rom_name.empty() && isspace(gz_rom_name.back()))
                 gz_rom_name.pop_back();
 
-            if (settings.opt_ucode) {
+            if (settings.rom_opt_ucode) {
                 cmd = gru + " lua/inject_ucode.lua " + quote(rom_path) + " "
-                      + quote(settings.ucode_path);
+                      + quote(settings.rom_ucode_path);
                 emit output(QString::fromStdString("executing: " + cmd + "\n"));
                 status = invoke_subprogram(cmd, "", output_to_log,
                                            output_to_log);
@@ -555,13 +555,13 @@ int Patcher::patch()
                 cmd += " --raphnet";
             else if (settings.wad_remap == PatcherSettings::controller_remap_t::NONE)
                 cmd += " --disable-controller-remappings";
-            if (!settings.channel_id.empty())
-                cmd += " -i " + quote(settings.channel_id);
-            if (!settings.channel_title.empty())
-                cmd += " -t " + quote(settings.channel_title);
+            if (!settings.wad_channel_id.empty())
+                cmd += " -i " + quote(settings.wad_channel_id);
+            if (!settings.wad_channel_title.empty())
+                cmd += " -t " + quote(settings.wad_channel_title);
             cmd += " -r " + std::to_string(settings.wad_region);
-            if (settings.opt_extrom)
-                cmd += " -m " + quote(settings.extrom_path);
+            if (settings.wad_opt_extrom)
+                cmd += " -m " + quote(settings.wad_extrom_path);
             cmd += " -o " + quote(wad_path) + " " + quote(settings.wad_path);
 
             emit output(QString::fromStdString("executing: " + cmd + "\n"));
@@ -605,13 +605,13 @@ int Patcher::patch()
                 cmd += " --raphnet";
             else if (settings.iso_remap == PatcherSettings::controller_remap_t::NONE)
                 cmd += " --disable-controller-remappings";
-            if (!settings.game_id.empty())
-                cmd += " -i " + quote(settings.game_id);
-            if (!settings.game_name.empty())
-                cmd += " -t " + quote(settings.game_name);
+            if (!settings.iso_game_id.empty())
+                cmd += " -i " + quote(settings.iso_game_id);
+            if (!settings.iso_game_name.empty())
+                cmd += " -t " + quote(settings.iso_game_name);
             if (settings.iso_opt_extrom)
                 cmd += " -m " + quote(settings.iso_extrom_path);
-            if (settings.iso_is_mq && settings.iso_opt_extrom_mq)
+            if (settings.iso_opt_extrom_mq)
                 cmd += " --mq-rom " + quote(settings.iso_extrom_mq_path);
             if (!settings.iso_do_trim)
                 cmd += " --no-trim";

--- a/patcher.h
+++ b/patcher.h
@@ -12,16 +12,17 @@ public:
     {
         ROM,
         WAD,
+        ISO,
     };
 
-    enum wad_remap_t
+    enum controller_remap_t
     {
         DEFAULT,
         RAPHNET,
         NONE,
     };
 
-    enum wad_region_t
+    enum console_region_t
     {
         JAP,
         USA,
@@ -31,17 +32,31 @@ public:
 
     patch_mode_t patch_mode = patch_mode_t::ROM;
 
+    // Patch a ROM
     std::string rom_path;
     std::string ucode_path;
     bool opt_ucode = false;
 
+    // Patch a WAD
     std::string wad_path;
     std::string extrom_path;
     bool opt_extrom = false;
-    enum wad_remap_t wad_remap = wad_remap_t::DEFAULT;
+    enum controller_remap_t wad_remap = controller_remap_t::DEFAULT;
     std::string channel_id;
     std::string channel_title;
-    enum wad_region_t wad_region = wad_region_t::FREE;
+    enum console_region_t wad_region = console_region_t::FREE;
+
+    // Patch an ISO
+    std::string iso_path;
+    std::string iso_extrom_path;
+    bool iso_is_mq = false; // "true" if the base ISO ID is "D43J01" or "D43E01"
+    bool iso_no_trim = false; // "false" to remove the useless files to save space
+    bool iso_opt_extrom = false;
+    std::string iso_extrom_mq_path;
+    bool iso_opt_extrom_mq = false;
+    enum controller_remap_t iso_remap = controller_remap_t::DEFAULT;
+    std::string game_id;
+    std::string game_name;
 };
 
 class Patcher : public QThread

--- a/patcher.h
+++ b/patcher.h
@@ -50,7 +50,7 @@ public:
     std::string iso_path;
     std::string iso_extrom_path;
     bool iso_is_mq = false; // "true" if the base ISO ID is "D43J01" or "D43E01"
-    bool iso_no_trim = false; // "false" to remove the useless files to save space
+    bool iso_do_trim = true; // "true" to remove the useless files to save space
     bool iso_opt_extrom = false;
     std::string iso_extrom_mq_path;
     bool iso_opt_extrom_mq = false;

--- a/patcher.h
+++ b/patcher.h
@@ -34,29 +34,28 @@ public:
 
     // Patch a ROM
     std::string rom_path;
-    std::string ucode_path;
-    bool opt_ucode = false;
+    std::string rom_ucode_path;
+    bool rom_opt_ucode = false;
 
     // Patch a WAD
     std::string wad_path;
-    std::string extrom_path;
-    bool opt_extrom = false;
+    std::string wad_extrom_path;
+    bool wad_opt_extrom = false;
     enum controller_remap_t wad_remap = controller_remap_t::DEFAULT;
-    std::string channel_id;
-    std::string channel_title;
+    std::string wad_channel_id;
+    std::string wad_channel_title;
     enum console_region_t wad_region = console_region_t::FREE;
 
     // Patch an ISO
     std::string iso_path;
     std::string iso_extrom_path;
-    bool iso_is_mq = false; // "true" if the base ISO ID is "D43J01" or "D43E01"
-    bool iso_do_trim = true; // "true" to remove the useless files to save space
-    bool iso_opt_extrom = false;
     std::string iso_extrom_mq_path;
+    bool iso_opt_extrom = false;
     bool iso_opt_extrom_mq = false;
+    bool iso_do_trim = true; // "true" to remove the useless files to save space
     enum controller_remap_t iso_remap = controller_remap_t::DEFAULT;
-    std::string game_id;
-    std::string game_name;
+    std::string iso_game_id;
+    std::string iso_game_name;
 };
 
 class Patcher : public QThread


### PR DESCRIPTION
This PR adds support for patching ISO files (for MQ JP, MQ US, CE JP and CE US), the practice rom can be booted on GameCube now so this is another step we have to do for the future release™ (and I say "can be booted" because we still have gameplay issues to fix)

<details>
<summary>Changes</summary>

- update the ui to add a "Patch an ISO" tab
  - add ISO file selection
  - add external ROM selection
  - add external MQ ROM selection
  - hide the extenal MQ ROM button and checkbox if the selected ISO is not an MQ ISO (basically it just reads the first bytes of the file as it's the game's ID and it displays a message saying "This game doesn't have Master Quest" if it's not the MQ JP or US ISO)
  - add the options (controller remapping, game id, game name and a checkbox to toggle the removal of the large files from the ISO to make it lighter)
- disable the "select" buttons if the "use external rom" checkboxes aren't checked
- move each tab's widget connections to their own function (`init_rom_tab`/`init_wad_tab`/`init_iso_tab`), I can revert this if necessary but it helped me while figuring out what's going on (and not mixing things up)
- implement the `Go!` button update logic for ISO files
- add `lua/patch-iso.lua` to the list of necessary files in `check_files()`
- give generic names to wad-specific types (as it's shared by iso patching):
  - `wad_remap_t` -> `controller_remap_t`
  - `wad_region_t` -> `console_region_t` (though now that I think about it it's not used by ISO patching so I can revert this if necessary)
- implement patching logic for ISOs in `Patcher::patch()`
- update the gitignore file

and I think that's all I did, this was based on the WAD logic btw
</details>

To test this you will need the following files:
- [`patch-iso.lua`](https://pastebin.com/ce0tFXy5) (which was made based on `patch-wad.lua` and [`make-iso.lua`](https://github.com/cadmic/gz/blob/gc-build/lua/make-iso.lua))
- the latest revision of [gzinject](https://github.com/PracticeROM/gzinject) (note: this got autobuilds, I used the windows one for my own tests)
- the latest revision of [homeboy](https://github.com/PracticeROM/homeboy)
- the new [gzi patches](https://github.com/cadmic/gz/tree/gc-build/gzi)
- the updated [`rom_table.lua`](https://github.com/cadmic/gz/blob/gc-build/lua/rom_table.lua)

I did my tests half on WSL and half on native Windows, both worked properly